### PR TITLE
Fixed the looping webpack updates

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -11,6 +11,7 @@ module.exports = merge(common, {
         filename: 'bundle.js'
     },
     devServer: {
+        hot: false,
         port: 9091,
         historyApiFallback: true,
         devMiddleware: {


### PR DESCRIPTION
As long as the app is running in `StrictMode` it will always render twice in development mode. Aside from that I think I patched the random updates. 