### PR TITLE
Graph layout edits, Sim 2

### DIFF
--- a/media/js/src/simulationTwo/scatterPlot2.jsx
+++ b/media/js/src/simulationTwo/scatterPlot2.jsx
@@ -11,10 +11,10 @@ export const ScatterPlot2 = ({ setAppRvalue,
 }) => {
     // const [data, setData] = useState([]);
     const data = [
-        { x: 1, y: 2, z: 3 }, { x: 2, y: 3, z: 4}, { x: 3, y: 4, z: 5},
-        { x: 4, y: 5, z: 6}, { x: 5, y: 6, z: 7}, { x: 6, y: 7, z: 8},
-        { x: 7, y: 8, z: 9}, { x: 8, y: 9, z: 10}, { x: 9, y: 10, z: 11},
-        { x: 10, y: 11, z: 12}
+        { x: 1, y: 3, z: 3 }, { x: 2, y: 6, z: 4}, { x: 3, y: 1, z: 5},
+        { x: 4, y: 2, z: 6}, { x: 5, y: 2, z: 7}, { x: 6, y: 25, z: 8},
+        { x: 7, y: 3, z: 9}, { x: 8, y: 8, z: 10}, { x: 9, y: 7, z: 11},
+        { x: 10, y: 8, z: 12}
     ];
     const [regressionLine, setRegressionLine] = useState(null);
     // fetch('../../../../json/Income.json').then(response => (
@@ -141,11 +141,11 @@ export const ScatterPlot2 = ({ setAppRvalue,
                 layout={{
                     title: 'Single Variable Linear Regression',
                     showlegend: false,
-                    xaxis: { title: 'X Axis' },
+                    xaxis: { title: 'X Axis', minallowed: 0},
                     yaxis: {
                         title: 'Y Axis',
-                        scaleanchor: 'x',
                         scaleratio: 1,
+                        minallowed: 0,
                     },
                     ...(plotType === '2d' ? { dragmode: 'pan' } : {}),
                 }}


### PR DESCRIPTION
Playing around with Plotly. I remember there was a discussion about disabling the display of negative values, and I think I found a solution, so I made a PR to show it. Note: It only affects Sim 2 as of now, but I can extend it to Sim 1.

We might also consider generic settings for the plotting layout if a lot of the simulations end up being similar.