### PR TITLE
Fixed Sim 1 graph scaling issue

### DIFF
--- a/media/js/src/simulationOne/scatterPlot.jsx
+++ b/media/js/src/simulationOne/scatterPlot.jsx
@@ -210,18 +210,10 @@ export const ScatterPlot = ({ N, yCorrelation, seed, setAppRvalue,
                         xaxis: {
                             title: 'X Axis',
                             dtick: 25,
-                            range: [Math.min(...data.map(
-                                point => point.x)),
-                            Math.max(...data.map(point => point.x))]
                         },
                         yaxis: {
                             title: 'Y Axis',
-                            scaleanchor: 'x',
-                            scaleratio: 1,
                             dtick: 25,
-                            range: [Math.min(...data.map(
-                                point => point.y)) - 10,
-                            Math.max(...data.map(point => point.y)) + 10]
                         }
                     }),
                     ...(plotType === '2d' ? { dragmode: 'pan' } : {}),


### PR DESCRIPTION
Turns out there was some weird interaction between the defined range and the scale anchor/ratio. Allowing the defaults seems to have resolved the issue.